### PR TITLE
Fix bug in test case variable name

### DIFF
--- a/src/testcase/statements/Statement.ts
+++ b/src/testcase/statements/Statement.ts
@@ -27,7 +27,7 @@ export abstract class Statement {
   protected constructor(type: string, uniqueId: string) {
     this._type = type;
     this._uniqueId = uniqueId;
-    this._varName = type + uniqueId;
+    this._varName = type.replace("[]", "array") + uniqueId;
   }
 
   /**


### PR DESCRIPTION
The variable names that are produced in the framework use a combination
of the type and the unique id. However, when a type is an array it
causes an error. JavaScript does not allow square brackets in variable
names.