### PR TITLE
Update dependencies to fix github build

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.3.0",
     "jsdoc": "^3.6.7",
-    "mocha": "^10.0.0",
+    "mocha": "^9.2.2",
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",
     "sinon": "^9.2.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/chai": "^4.2.19",
     "@types/cli-progress": "^3.9.2",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.37",
+    "@types/node": "^18.7.8",
     "@types/sinon": "^9.0.11",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
@@ -74,7 +74,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",
     "sinon": "^9.2.4",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.9.1",
     "typescript": "^4.3.5"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.3.0",
     "jsdoc": "^3.6.7",
-    "mocha": "^8.4.0",
+    "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",
     "sinon": "^9.2.4",


### PR DESCRIPTION
The github build (and my local build as well) was failing because

```
Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
```
Upgrading the `ts-node` and `@types/nodes` dependencies fixes this. See [stackoverflow](https://stackoverflow.com/questions/72488958/false-expression-non-string-value-passed-to-ts-resolvetypereferencedirective)

Also updated `mocha` to get rid of an audit warning.