### PR TITLE
Close existing logger before creating new one.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/chai": "^4.2.19",
     "@types/cli-progress": "^3.9.2",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.37",
+    "@types/node": "^18.7.8",
     "@types/sinon": "^9.0.11",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
@@ -74,7 +74,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",
     "sinon": "^9.2.4",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.9.1",
     "typescript": "^4.3.5"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.3.0",
     "jsdoc": "^3.6.7",
-    "mocha": "^8.4.0",
+    "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",
     "sinon": "^9.2.4",

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -138,6 +138,10 @@ export function getLogger() {
 }
 
 export function setupLogger() {
+  if (logger) {
+    // close existing one before creating a new one.
+    logger.close()
+  }
   const settings = getLoggerSettings(Properties.log_directory);
 
   const options: LoggerOptions = <LoggerOptions>{


### PR DESCRIPTION
Extension of #99 which helps to get rid of the warning raised during tests:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added to [process]. Use emitter.setMaxListeners() to increase limit
```

The simple change is in commit 87b0bf9f8b539db626076202c36935e37366255c
