### PR TITLE
Update node versions in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
         # Run the pipeline on all the currently supported LTS versions and the upcoming version
-        node-version: [10, 12, 14, 16]
+        node-version: [14, 16, 18]
 
         # Run the pipeline on all the currently supported architectures
         architecture: [x64]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       # Publish to npm


### PR DESCRIPTION
The list of LTS node versions in the build workflow was outdated. The new list matches the current supported LTS versions found here: https://nodejs.org/en/about/releases/