### PR TITLE
Simplify test setup by mocking the user interface

### DIFF
--- a/src/ui/UserInterface.ts
+++ b/src/ui/UserInterface.ts
@@ -17,8 +17,8 @@
  */
 
 export abstract class UserInterface {
-  protected silent: boolean;
-  protected verbose: boolean;
+  silent: boolean;
+  verbose: boolean;
 
   constructor(silent = false, verbose = false) {
     this.silent = silent;

--- a/test/search/metaheuristics/MOSA.test.ts
+++ b/test/search/metaheuristics/MOSA.test.ts
@@ -1,14 +1,8 @@
 import * as chai from "chai";
 import {
-  guessCWD,
-  loadConfig,
-  processConfig,
-  setupLogger,
-  setupOptions,
   setUserInterface,
   CommandLineInterface,
   Properties,
-  Encoding,
   EncodingRunner,
   EncodingSampler,
 } from "../../../src";
@@ -18,7 +12,7 @@ import { DummySearchSubject } from "../../mocks/DummySubject.mock";
 import { BranchObjectiveFunction } from "../../../src";
 import { MockedMOSA } from "../../mocks/MOSAAdapter";
 import { DummyCrossover } from "../../mocks/DummyCrossover.mock";
-import { Test } from "mocha";
+import { createStubInstance } from "sinon";
 
 const expect = chai.expect;
 
@@ -26,19 +20,8 @@ const expect = chai.expect;
  * @author Annibale Panichella
  */
 describe("Test MOSA", function () {
-  before(async () => {
-    await guessCWD(null);
-    await setupOptions("", "");
-    await loadConfig();
-    await processConfig({}, "");
-    await setupLogger();
-
-    setUserInterface(
-      new CommandLineInterface(
-        Properties.console_log_level === "silent",
-        Properties.console_log_level === "verbose"
-      )
-    );
+  before(() => {
+    setUserInterface(createStubInstance(CommandLineInterface));
   });
 
   let objectives: Set<BranchObjectiveFunction<DummyEncodingMock>>;
@@ -120,6 +103,9 @@ describe("Test MOSA", function () {
   });
 
   it("Test Preference Sorting", () => {
+    // This test requires a defined population size.
+    Properties.population_size = 4;
+
     const ind1 = new DummyEncodingMock();
     ind1.setDummyEvaluation(Array.from(objectives), [2, 3]);
 

--- a/test/search/operators/CrowdingDistance.test.ts
+++ b/test/search/operators/CrowdingDistance.test.ts
@@ -2,16 +2,11 @@ import * as chai from "chai";
 import {
   CommandLineInterface,
   crowdingDistance,
-  guessCWD,
-  loadConfig,
-  processConfig,
-  Properties,
-  setupLogger,
-  setupOptions,
   setUserInterface,
 } from "../../../src";
 import { DummyEncodingMock } from "../../mocks/DummyEncoding.mock";
 import { BranchObjectiveFunction, ObjectiveFunction } from "../../../src";
+import { createStubInstance } from "sinon";
 
 const expect = chai.expect;
 
@@ -20,19 +15,8 @@ const expect = chai.expect;
  */
 
 describe("Crowding distance", function () {
-  beforeEach(async () => {
-    await guessCWD(null);
-    await setupOptions("", "");
-    await loadConfig();
-    await processConfig({}, "");
-    await setupLogger();
-
-    setUserInterface(
-      new CommandLineInterface(
-        Properties.console_log_level === "silent",
-        Properties.console_log_level === "verbose"
-      )
-    );
+  before(() => {
+    setUserInterface(createStubInstance(CommandLineInterface));
   });
 
   it("empty front", () => {

--- a/test/search/operators/DominanceComparator.test.ts
+++ b/test/search/operators/DominanceComparator.test.ts
@@ -3,15 +3,10 @@ import { DominanceComparator } from "../../../src/search/comparators/DominanceCo
 import {
   BranchObjectiveFunction,
   CommandLineInterface,
-  guessCWD,
-  loadConfig,
-  processConfig,
-  Properties,
-  setupLogger,
-  setupOptions,
   setUserInterface,
 } from "../../../src";
 import { DummyEncodingMock } from "../../mocks/DummyEncoding.mock";
+import { createStubInstance } from "sinon";
 
 const expect = chai.expect;
 
@@ -19,19 +14,8 @@ const expect = chai.expect;
  * @author Annibale Panichella
  */
 describe("Dominance comparator", function () {
-  before(async () => {
-    await guessCWD(null);
-    await setupOptions("", "");
-    await loadConfig();
-    await processConfig({}, "");
-    await setupLogger();
-
-    setUserInterface(
-      new CommandLineInterface(
-        Properties.console_log_level === "silent",
-        Properties.console_log_level === "verbose"
-      )
-    );
+  before(() => {
+    setUserInterface(createStubInstance(CommandLineInterface));
   });
 
   let objectives: Set<BranchObjectiveFunction<DummyEncodingMock>>;

--- a/test/search/operators/FasNonDomSorting.test.ts
+++ b/test/search/operators/FasNonDomSorting.test.ts
@@ -2,16 +2,11 @@ import * as chai from "chai";
 import {
   BranchObjectiveFunction,
   CommandLineInterface,
-  guessCWD,
-  loadConfig,
-  processConfig,
-  Properties,
-  setupLogger,
-  setupOptions,
   setUserInterface,
 } from "../../../src";
 import { DummyEncodingMock } from "../../mocks/DummyEncoding.mock";
 import { fastNonDomSorting } from "../../../src/search/operators/ranking/FastNonDomSorting";
+import { createStubInstance } from "sinon";
 
 const expect = chai.expect;
 
@@ -19,19 +14,8 @@ const expect = chai.expect;
  * @author Annibale Panichella
  */
 describe("Fast non-dominated sorting", function () {
-  before(async () => {
-    await guessCWD(null);
-    await setupOptions("", "");
-    await loadConfig();
-    await processConfig({}, "");
-    await setupLogger();
-
-    setUserInterface(
-      new CommandLineInterface(
-        Properties.console_log_level === "silent",
-        Properties.console_log_level === "verbose"
-      )
-    );
+  before(() => {
+    setUserInterface(createStubInstance(CommandLineInterface));
   });
 
   it("Sort three solutions", () => {

--- a/test/search/operators/TournamentSelection.test.ts
+++ b/test/search/operators/TournamentSelection.test.ts
@@ -1,17 +1,12 @@
 import * as chai from "chai";
 import {
   BranchObjectiveFunction,
-  guessCWD,
-  loadConfig,
-  processConfig,
-  setupLogger,
-  setupOptions,
   CommandLineInterface,
-  Properties,
   setUserInterface,
 } from "../../../src";
 import { DummyEncodingMock } from "../../mocks/DummyEncoding.mock";
 import { tournamentSelection } from "../../../src/search/operators/selection/TournamentSelection";
+import { createStubInstance } from "sinon";
 
 const expect = chai.expect;
 
@@ -23,19 +18,8 @@ global.Math = mockMath;
  * @author Annibale Panichella
  */
 describe("Tournament selection", function () {
-  before(async () => {
-    await guessCWD(null);
-    await setupOptions("", "");
-    await loadConfig();
-    await processConfig({}, "");
-    await setupLogger();
-
-    setUserInterface(
-      new CommandLineInterface(
-        Properties.console_log_level === "silent",
-        Properties.console_log_level === "verbose"
-      )
-    );
+  before(() => {
+    setUserInterface(createStubInstance(CommandLineInterface));
   });
 
   it("Small Tournament size", () => {


### PR DESCRIPTION
The UI is used as a logging API and used in many classes. But its setup requires a tricky series of calls setting global variables.

Replace this setup by a simple (Sinon) mock of the UI. Due to a limitation in Sinon, this meant that the protected `silent`/`verbose` field of the `UserInterface` class had to be public, but that seems worth the simplicity in return. Also, these properties don't seem to be _used_ anywhere, so maybe they can be removed?

Using a mock also makes it mandatory to explicitly set properties that steer the algorithms, making the tests self documenting and less fragile. Setting such a property was only needed for one test case: Testing preference sorting in MOSA.