### PR TITLE
infra: update CI infrastructure settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,12 @@ name: build
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths-ignore:
       - "docs/"
       - "**.md"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths-ignore:
       - "docs/"
       - "**.md"
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
         # Run the pipeline on all the currently supported LTS versions and the upcoming version
-        node-version: [14, 16, 18]
+        node-version: [14, 16, 18, 19]
 
         # Run the pipeline on all the currently supported architectures
         architecture: [x64]


### PR DESCRIPTION
- The CI was only running on the main, but we now added a develop branch
- The CI was not using the latest Node.JS version