### PR TITLE
Tournament selection bug

### DIFF
--- a/libraries/search/lib/operators/selection/TournamentSelection.ts
+++ b/libraries/search/lib/operators/selection/TournamentSelection.ts
@@ -40,13 +40,16 @@ export function tournamentSelection<T extends Encoding>(
   for (let tournament = 0; tournament < tournamentSize - 1; tournament++) {
     const solution = prng.pickOne(population);
 
-    // the winner is the solution with the best (smaller) non-dominance rank
-    if (solution.getRank() < winner.getRank()) winner = solution;
-
+    // The winner is the solution with the best (smaller) non-dominance rank.
     // At the same level or ranking, the winner is the solution with the best (largest)
-    // crowding distance
-    if (solution.getCrowdingDistance() > winner.getCrowdingDistance())
+    // crowding distance.
+    if (
+      solution.getRank() < winner.getRank() ||
+      (solution.getRank() === winner.getRank() &&
+        solution.getCrowdingDistance() > winner.getCrowdingDistance())
+    ) {
       winner = solution;
+    }
   }
 
   return winner;


### PR DESCRIPTION
In the buggy version, when a selected solution had a larger crowding distance than the current winner, it was preferred over the winner. This should not happen.

The comparison should first be based on the ranking and only then on the crowding distance.

The winner is the solution with the best (smaller) non-dominance rank. At the same level or ranking, the winner is the solution with the best (largest) crowding distance.